### PR TITLE
Add Semigroup and Monoid instances for Fake

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for fakedata
 
+## 0.6.1
+
+* Add `Semigroup` and `Monoid` instances to `Fake`
+
 ## 0.6.0
 
 * Fix API for "ar" locale. Add test coverage.

--- a/src/Faker.hs
+++ b/src/Faker.hs
@@ -36,6 +36,7 @@ import Control.Monad (ap)
 import Control.Monad.IO.Class
 import qualified Data.HashMap.Strict as HM
 import Data.IORef
+import Data.Semigroup (Semigroup, (<>))
 import Data.Text (Text)
 import Data.Typeable
 import Data.Vector (Vector)
@@ -208,11 +209,14 @@ instance MonadIO Fake where
   liftIO :: IO a -> Fake a
   liftIO xs = Fake (\_ -> xs >>= pure)
 
+-- | @since 0.6.1
 instance Semigroup a => Semigroup (Fake a) where
   mx <> my = (<>) <$> mx <*> my
 
+-- | @since 0.6.1
 instance Monoid a => Monoid (Fake a) where
   mempty = pure mempty
+  mappend mx my = mappend <$> mx <*> my
 
 -- | Generate fake value with 'defaultFakerSettings'
 --

--- a/src/Faker.hs
+++ b/src/Faker.hs
@@ -208,6 +208,12 @@ instance MonadIO Fake where
   liftIO :: IO a -> Fake a
   liftIO xs = Fake (\_ -> xs >>= pure)
 
+instance Semigroup a => Semigroup (Fake a) where
+  mx <> my = (<>) <$> mx <*> my
+
+instance Monoid a => Monoid (Fake a) where
+  mempty = pure mempty
+
 -- | Generate fake value with 'defaultFakerSettings'
 --
 -- @

--- a/test/OtherSpec.hs
+++ b/test/OtherSpec.hs
@@ -6,6 +6,7 @@ module OtherSpec where
 import Control.Monad.Catch
 import Control.Monad.IO.Class
 import qualified Data.Map as M
+import Data.Semigroup ((<>))
 import Data.Text hiding (all, map)
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
@@ -54,3 +55,13 @@ spec = do
       ga <-
         generateWithSettings (setDeterministic defaultFakerSettings) AP.author
       ga `shouldBe` "Steuber, Donnelly and Goldner"
+  describe "Semigroup instance of Fake" $
+    it "can be appended and it is associative" $ do
+      phraseL <- generate $ (pure "Hello " <> name) <> pure "!"
+      phraseR <- generate $ pure "Hello " <> (name <> pure "!")
+      phraseL `shouldBe` "Hello Dominga Stiedemann!"
+      phraseR `shouldBe` "Hello Dominga Stiedemann!"
+  describe "Monoid instance of Fake" $
+    it "mappend mempty doesn't modify the other operand" $ do
+      name' <- generate $ name `mappend` mempty
+      name' `shouldBe` "Georgianne Steuber"


### PR DESCRIPTION
We can alternatively use `GeneralizedNewtypeDeriving`, it generates the same